### PR TITLE
docs: fix plural possessive inconsistency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ both keep their own painted textures, so the tint never runs at all in the commo
 side a figure belongs to is therefore said three times over, in channels that fail differently:
 a **band painted on the tile it stands on**, a **rim light along its silhouette**, and its
 **rank crest** — azure for the near side, ember for the far one. The band also differs in shape
-(the kingdoms' plain double band against the empire's spiked sun collar), so the answer survives
+(the kingdom's plain double band against the empire's spiked sun collar), so the answer survives
 a colour-blind player as well as a dark hall. The band is *painted* rather than added to the
 tile: the old additive glow disappeared into every lit marble square, which is most of the
 board. The rim is a fresnel edge injected beside the dissolve shader and added before tone


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 485).

## Problem

The text uses "kingdoms'"'" (plural possessive) but the Ivory Kingdom is a single entity referenced consistently as singular throughout the document. It is paired with "empire's" (singular possessive) in the same sentence, creating an inconsistent possessive form.

The problematic text:

```markdown
(the kingdoms' plain double band against the empire's spiked sun collar), so the answer survives
```

## Fix

Replaced with:

```markdown
(the kingdom's plain double band against the empire's spiked sun collar), so the answer survives
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text